### PR TITLE
JWT認証に失敗した場合の処理の実装

### DIFF
--- a/src/main/java/com/example/game_lobby_server/service/BattleRecordService.java
+++ b/src/main/java/com/example/game_lobby_server/service/BattleRecordService.java
@@ -31,7 +31,9 @@ public class BattleRecordService {
 
         // 総試合数、勝利回数、鬼での勝利回数を計算
         int totalMatches = records.size();
-        int totalWins = (int) records.stream().filter(BattleRecord::isWin).count();
+        int totalWins = (int) records.stream()
+                .filter(record -> record.isWin() && "村人".equals(record.getRole()) && record.getRanking() == 1)
+                .count();
         int demonWins = (int) records.stream()
                 .filter(record -> record.isWin() && "鬼".equals(record.getRole()))
                 .count();

--- a/src/main/java/com/example/game_lobby_server/support/JWTAuthorizationFilter.java
+++ b/src/main/java/com/example/game_lobby_server/support/JWTAuthorizationFilter.java
@@ -1,7 +1,10 @@
 package com.example.game_lobby_server.support;
 
+import com.example.game_lobby_server.dto.ResponseDto;
 import com.example.game_lobby_server.service.JwtSecretKeyService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,14 +32,28 @@ public class JWTAuthorizationFilter extends BasicAuthenticationFilter {
                                     FilterChain chain) throws IOException, ServletException {
         String header = req.getHeader("Authorization");
 
+        // Authorization ヘッダーがない場合もエラーを返す
         if (header == null || !header.startsWith("Bearer ")) {
-            chain.doFilter(req, res);
+            ResponseDto responseDto = new ResponseDto("Authorization header is missing or invalid", "error");
+            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 401 Unauthorized
+            res.setContentType("application/json");
+            res.getWriter().write(convertToJson(responseDto));  // JSON形式でレスポンスを返す
             return;
         }
 
-
+        // JWT認証を試みる
         UsernamePasswordAuthenticationToken authentication = getAuthentication(req);
 
+        if (authentication == null) {
+            // 認証に失敗した場合、エラーメッセージをレスポンスにセット
+            ResponseDto responseDto = new ResponseDto("Invalid token", "error");
+            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 401 Unauthorized
+            res.setContentType("application/json");
+            res.getWriter().write(convertToJson(responseDto));  // JSON形式でレスポンスを返す
+            return;
+        }
+
+        // 認証が成功した場合
         SecurityContextHolder.getContext().setAuthentication(authentication);
         chain.doFilter(req, res);
     }
@@ -44,20 +61,50 @@ public class JWTAuthorizationFilter extends BasicAuthenticationFilter {
     private UsernamePasswordAuthenticationToken getAuthentication(HttpServletRequest request) {
         String token = request.getHeader("Authorization");
         if (token != null) {
-            // JwtSecretKeyService を使用してシークレットキーを取得
-            String secret = jwtSecretKeyService.getSecretKey();
+            try {
+                // JwtSecretKeyService を使用してシークレットキーを取得
+                String secret = jwtSecretKeyService.getSecretKey();
 
-            String user = Jwts.parser()
-                    .setSigningKey(secret.getBytes())
-                    .parseClaimsJws(token.replace("Bearer ", ""))
-                    .getBody()
-                    .getSubject();
+                String user = Jwts.parser()
+                        .setSigningKey(secret.getBytes())
+                        .parseClaimsJws(token.replace("Bearer ", ""))
+                        .getBody()
+                        .getSubject();
 
-            if (user != null) {
-                return new UsernamePasswordAuthenticationToken(user, null, new ArrayList<>());
+                if (user != null) {
+                    return new UsernamePasswordAuthenticationToken(user, null, new ArrayList<>());
+                }
+            } catch (SignatureException e) {
+                // JWTの署名が一致しない場合
+                if (request instanceof HttpServletResponse) {
+                    HttpServletResponse res = (HttpServletResponse) request;
+                    ResponseDto responseDto = new ResponseDto("JWT signature does not match locally computed signature", "error");
+                    try {
+                        responseDto.setMessage(e.getMessage());  // 例外メッセージを追加
+                        responseDto.setStatus("error");
+                        res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 401 Unauthorized
+                        res.setContentType("application/json");
+                        res.getWriter().write(convertToJson(responseDto));  // JSON形式でレスポンスを返す
+                    } catch (IOException ioException) {
+                        ioException.printStackTrace();
+                    }
+                }
+                return null;
+            } catch (Exception e) {
+                return null;
             }
-            return null;
         }
         return null;
+    }
+
+    private String convertToJson(ResponseDto responseDto) {
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.writeValueAsString(responseDto);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "{}";  // 失敗した場合は空の JSON
+        }
     }
 }


### PR DESCRIPTION
## 修正内容

### **`JWTAuthorizationFilterクラス`**
-  **Authorizationヘッダーが存在しないか、Bearerで始まっていない場合にエラーメッセージを返す**
1.  ヘッダーが不正である場合、ResponseDtoを作成し、エラーメッセージを設定
2. ステータスコードを401 Unauthorizedに設定
3. res.getWriter().write(convertToJson(responseDto))を使用して、エラーメッセージをJSON形式でレスポンスボディに書き込む

- **JWTトークンを使った認証が失敗した場合に、エラーメッセージを返す**
1.  トークンの検証を行う
2. JWTが不正であったり、署名が一致しない場合、authenticationはnullとする
3. 認証に失敗した場合、ResponseDtoというDTO（Data Transfer Object）を作成し、エラーメッセージを設定
4. res.getWriter().write(convertToJson(responseDto))を使用して、エラーメッセージをJSON形式でレスポンスボディに書き込む

- **JWTの署名が一致せずにSignatureExceptionが発生した場合**
1.  トークンの署名検証を行う
2. SignatureExceptionがスローされた場合、エラーハンドリングを実行
3. ResponseDtoを作成し、エラーメッセージを設定
4. res.getWriter().write(convertToJson(responseDto))を使用して、エラーメッセージをJSON形式でレスポンスボディに書き込む

- **ResponseDtoオブジェクトをJSON形式に変換する**
- `convertToJsonメソッド`
1.  ObjectMapperを使用してオブジェクトをJSON文字列に変換
2. writeValueAsStringメソッドにResponseDtoオブジェクトを渡し、JSON形式の文字列を生成